### PR TITLE
Adding missing ensure

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -18,7 +18,7 @@ sv_maxclients {{maxClients}}
 sv_endpointprivacy true
 
 set steam_webApiKey "none"
-sets tags "vorpcore, qadr_server, c#, qadr_version: {{recipeVersion}}"
+sets tags "vorpcore, recipe_version: {{recipeVersion}}"
 
 ## You MAY edit the following:
 sv_licenseKey "{{svLicense}}"
@@ -40,7 +40,7 @@ ensure mapmanager
 ensure chat
 ensure spawnmanager
 ensure sessionmanager-rdr3
-
+ensure fivem
 ensure rconlog
 ensure interiors
 


### PR DESCRIPTION
**What this resolves:** This minor update should fix the infinite load people are getting after installing, which was failing to load model assets/natives on server start/join. 

**Issue:** I seemed to have forgotten the `ensure fivem` in the server.cfg setup when stripping out non-vorp official scripts. 

![image](https://user-images.githubusercontent.com/10902965/166159051-87705f9f-835d-4a69-acff-d4436f7ab7b8.png)

