### PR TITLE
Specify the key length for the characters.coords column.

### DIFF
--- a/MariaDB.sql
+++ b/MariaDB.sql
@@ -69,7 +69,7 @@ CREATE TABLE `characters` (
   KEY `identifier` (`identifier`), 
   KEY `compPlayer` (`compPlayer`(768)),
   KEY `inventory` (`inventory`(768)),
-  KEY `coords` (`coords`),
+  KEY `coords` (`coords`(768)),
   KEY `money` (`money`),
   KEY `meta` (`meta`),
   KEY `steamname` (`steamname`),


### PR DESCRIPTION
This PR specifies the key length for the `coords` column in the `characters` table. By setting a key length, we can prevent the following MySQL error: `BLOB/TEXT column 'coords' used in key specification without a key length`