### PR TITLE
Chore: fix Wrong pointed location for weathersync permissions and remove old ensure for interiors is now moonshine_interiors

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -38,7 +38,6 @@ ensure hardcap
 ## Dependencies
 ensure oxmysql
 ensure weathersync
-ensure interiors
 ensure syn_minigame
 ensure lockpick
 ensure PolyZone
@@ -46,7 +45,7 @@ ensure moonshine_interiors
 ensure vorp_menu
 
 ## Permissions
-exec resources/[VORP]/[essentials]/weathersync/permissions.cfg
+exec resources/[standalone]/weathersync/permissions.cfg
 exec resources/[VORP]/vorp_admin/vorp_perms.cfg
 
 ## VORP Resources


### PR DESCRIPTION
was pointing to the wrong place 

old 
exec resources/[VORP]/[essentials]/weathersync/permissions.cfg

new 

exec resources/[standalone]/weathersync/permissions.cfg

this the right one 


removed old ensure interiors it is now moonshine_interiors 
