### PR TITLE
Bug fix: remove ./tmp folder

### DIFF
--- a/vorp_recipe.yaml
+++ b/vorp_recipe.yaml
@@ -325,3 +325,5 @@ tasks:
 # Clean up temporary files
   - action: remove_path
     path: ./temp
+  - action: remove_path
+    path: ./tmp


### PR DESCRIPTION
During the installation the recipe is putting temporary files into the `./tmp` folder but is not removing the whole folder later on like it is done with `./temp`.

This PR just removes the `./tmp` folder at the end of the actions.