### PR TITLE
Change oxmysql src to cox repo

### DIFF
--- a/vorp_recipe.yaml
+++ b/vorp_recipe.yaml
@@ -265,7 +265,7 @@ tasks:
 # Download oxmysql
   - action: download_file
     path: ./tmp/files/oxmysql.zip
-    url: https://github.com/overextended/oxmysql/releases/latest/download/oxmysql.zip
+    url: https://github.com/CommunityOx/oxmysql/releases/latest/download/oxmysql.zip
   - action: unzip
     dest: ./resources/[standalone]
     src: ./tmp/files/oxmysql.zip


### PR DESCRIPTION
Change oxmysql src to cox repo

Justification : Community Ox is an organization dedicated to maintaining forks of most Overextended resources after the original Overextended team archived their work. 